### PR TITLE
fix: normalize internal state timestamps

### DIFF
--- a/src/dlt_iceberg/destination_client.py
+++ b/src/dlt_iceberg/destination_client.py
@@ -63,6 +63,51 @@ logger = logging.getLogger(__name__)
 _PENDING_FILES: Dict[str, Dict[str, List[Tuple[TTableSchema, str, pa.Table]]]] = {}
 _PENDING_FILES_LOCK = threading.Lock()
 
+_INTERNAL_TIMESTAMP_COLUMNS: Dict[str, Tuple[str, ...]] = {
+    "_dlt_pipeline_state": ("created_at",),
+    "_dlt_loads": ("inserted_at",),
+    "_dlt_version": ("inserted_at",),
+}
+
+
+def _normalize_internal_metadata_timestamps(
+    table_name: str,
+    arrow_table: pa.Table,
+    target_schema: Optional[pa.Schema] = None,
+) -> pa.Table:
+    """Keep dlt metadata timestamp batches aligned with their Iceberg table."""
+    timestamp_columns = _INTERNAL_TIMESTAMP_COLUMNS.get(table_name)
+    if not timestamp_columns:
+        return arrow_table
+
+    target_fields = {field.name: field for field in target_schema} if target_schema else {}
+    changed = False
+    fields = []
+    for field in arrow_table.schema:
+        if (
+            field.name not in timestamp_columns
+            or not pa.types.is_timestamp(field.type)
+        ):
+            fields.append(field)
+            continue
+
+        target_field = target_fields.get(field.name)
+        if target_field is not None and pa.types.is_timestamp(target_field.type):
+            target_type = target_field.type
+        else:
+            target_type = pa.timestamp("us")
+
+        if field.type != target_type:
+            fields.append(pa.field(field.name, target_type, nullable=field.nullable))
+            changed = True
+        else:
+            fields.append(field)
+
+    if not changed:
+        return arrow_table
+
+    return arrow_table.cast(pa.schema(fields, metadata=arrow_table.schema.metadata))
+
 
 @configspec
 class IcebergRestConfiguration(DestinationClientConfiguration):
@@ -953,14 +998,23 @@ class IcebergRestClient(JobClientBase, WithSqlClient, SupportsOpenTables, WithSt
         loads_table_name = self.schema.loads_table_name
         identifier = f"{self.config.namespace}.{loads_table_name}"
 
+        inserted_at = pendulum.now("UTC").naive()
+        load_row_schema = pa.schema([
+            pa.field("load_id", pa.string(), nullable=False),
+            pa.field("schema_name", pa.string(), nullable=True),
+            pa.field("status", pa.int64(), nullable=False),
+            pa.field("inserted_at", pa.timestamp("us"), nullable=True),
+            pa.field("schema_version_hash", pa.string(), nullable=True),
+        ])
         load_row = pa.table(
             {
                 "load_id": [load_id],
                 "schema_name": [self.schema.name],
                 "status": [0],
-                "inserted_at": [pendulum.now()],
+                "inserted_at": [inserted_at],
                 "schema_version_hash": [self.schema.version_hash],
-            }
+            },
+            schema=load_row_schema,
         )
 
         for attempt in range(self.config.max_retries):
@@ -1260,11 +1314,25 @@ class IcebergRestClient(JobClientBase, WithSqlClient, SupportsOpenTables, WithSt
                 except NoSuchTableError:
                     logger.info(f"Table {identifier} does not exist, will create")
 
+                target_schema = schema_to_pyarrow(iceberg_table.schema()) if table_exists else None
+                commit_file_data = [
+                    (
+                        table_schema,
+                        file_path,
+                        _normalize_internal_metadata_timestamps(
+                            table_name,
+                            arrow_table,
+                            target_schema=target_schema,
+                        ),
+                    )
+                    for table_schema, file_path, arrow_table in file_data
+                ]
+
                 # Create table if needed
                 if not table_exists:
                     # Use first file's Arrow table to generate schema
                     # Apply Iceberg compatibility first so schema uses compatible types
-                    first_arrow_table = ensure_iceberg_compatible_arrow_data(file_data[0][2])
+                    first_arrow_table = ensure_iceberg_compatible_arrow_data(commit_file_data[0][2])
                     iceberg_schema = convert_dlt_to_iceberg_schema(
                         table_schema, first_arrow_table
                     )
@@ -1293,7 +1361,7 @@ class IcebergRestClient(JobClientBase, WithSqlClient, SupportsOpenTables, WithSt
                     logger.info(f"Created table {identifier} at {iceberg_table.location()}")
                 else:
                     # Table exists - check if schema evolution is needed
-                    first_arrow_table = ensure_iceberg_compatible_arrow_data(file_data[0][2])
+                    first_arrow_table = ensure_iceberg_compatible_arrow_data(commit_file_data[0][2])
                     incoming_schema = convert_dlt_to_iceberg_schema(
                         table_schema, first_arrow_table
                     )
@@ -1313,7 +1381,7 @@ class IcebergRestClient(JobClientBase, WithSqlClient, SupportsOpenTables, WithSt
                 # Combine all Arrow tables and cast to match Iceberg schema
                 combined_tables = []
 
-                for _, file_path, arrow_table in file_data:
+                for _, file_path, arrow_table in commit_file_data:
                     # Cast to match Iceberg schema
                     # (compatibility conversions already applied when schema was created)
                     casted_table = cast_table_safe(

--- a/tests/test_with_state_sync.py
+++ b/tests/test_with_state_sync.py
@@ -13,9 +13,10 @@ from datetime import datetime
 import pyarrow as pa
 from pyiceberg.catalog import load_catalog
 from pyiceberg.schema import Schema as IcebergSchema
-from pyiceberg.types import NestedField, StringType, LongType, TimestampType
+from pyiceberg.types import NestedField, StringType, LongType, TimestampType, TimestamptzType
 
 import dlt
+from dlt.common import pendulum
 from dlt_iceberg import iceberg_rest
 
 
@@ -308,6 +309,140 @@ class TestWithStateSyncMethods:
         result_none = client.get_stored_state("other_pipeline")
         assert result_none is None, "Should return None for non-existent pipeline"
         print("   Correctly returned None for non-existent pipeline")
+
+    def test_state_table_created_at_timestamptz_batch_matches_existing_timestamp_schema(
+        self, catalog_setup, client
+    ):
+        """State metadata keeps created_at as Iceberg timestamp across runs."""
+        catalog = catalog_setup["catalog"]
+
+        iceberg_schema = IcebergSchema(
+            NestedField(1, "version", LongType(), required=True),
+            NestedField(2, "engine_version", LongType(), required=True),
+            NestedField(3, "pipeline_name", StringType(), required=True),
+            NestedField(4, "state", StringType(), required=True),
+            NestedField(5, "created_at", TimestampType(), required=True),
+            NestedField(6, "version_hash", StringType(), required=False),
+            NestedField(7, "_dlt_load_id", StringType(), required=False),
+        )
+        catalog.create_table(
+            identifier="test._dlt_pipeline_state",
+            schema=iceberg_schema,
+        )
+
+        aware_arrow_schema = pa.schema([
+            pa.field("version", pa.int64(), nullable=False),
+            pa.field("engine_version", pa.int64(), nullable=False),
+            pa.field("pipeline_name", pa.string(), nullable=False),
+            pa.field("state", pa.string(), nullable=False),
+            pa.field("created_at", pa.timestamp("us", tz="UTC"), nullable=False),
+            pa.field("version_hash", pa.string(), nullable=True),
+            pa.field("_dlt_load_id", pa.string(), nullable=True),
+        ])
+        aware_state_batch = pa.table({
+            "version": [1],
+            "engine_version": [1],
+            "pipeline_name": ["my_pipeline"],
+            "state": ['{"state": true}'],
+            "created_at": [pendulum.datetime(2024, 1, 1, 12, 0, 0, tz="UTC")],
+            "version_hash": ["hash1"],
+            "_dlt_load_id": ["load1"],
+        }, schema=aware_arrow_schema)
+        state_table_schema = {
+            "name": "_dlt_pipeline_state",
+            "write_disposition": "append",
+            "columns": {
+                "version": {"data_type": "bigint", "nullable": False},
+                "engine_version": {"data_type": "bigint", "nullable": False},
+                "pipeline_name": {"data_type": "text", "nullable": False},
+                "state": {"data_type": "text", "nullable": False},
+                "created_at": {"data_type": "timestamp", "nullable": False},
+                "version_hash": {"data_type": "text", "nullable": True},
+                "_dlt_load_id": {"data_type": "text", "nullable": True},
+            },
+        }
+
+        client._commit_table_files(
+            catalog=catalog,
+            identifier="test._dlt_pipeline_state",
+            table_name="_dlt_pipeline_state",
+            file_data=[(state_table_schema, "state.parquet", aware_state_batch)],
+        )
+
+        state_table = catalog.load_table("test._dlt_pipeline_state")
+        created_at_field = state_table.schema().find_field("created_at")
+        assert isinstance(created_at_field.field_type, TimestampType)
+
+        stored_rows = state_table.scan().to_arrow()
+        assert stored_rows.column("created_at").type == pa.timestamp("us")
+        assert len(stored_rows) == 1
+
+    def test_state_table_created_at_preserves_existing_timestamptz_schema(
+        self, catalog_setup, client
+    ):
+        """State metadata does not downgrade existing timestamptz tables."""
+        catalog = catalog_setup["catalog"]
+
+        iceberg_schema = IcebergSchema(
+            NestedField(1, "version", LongType(), required=True),
+            NestedField(2, "engine_version", LongType(), required=True),
+            NestedField(3, "pipeline_name", StringType(), required=True),
+            NestedField(4, "state", StringType(), required=True),
+            NestedField(5, "created_at", TimestamptzType(), required=True),
+            NestedField(6, "version_hash", StringType(), required=False),
+            NestedField(7, "_dlt_load_id", StringType(), required=False),
+        )
+        catalog.create_table(
+            identifier="test._dlt_pipeline_state_tz",
+            schema=iceberg_schema,
+        )
+
+        aware_arrow_schema = pa.schema([
+            pa.field("version", pa.int64(), nullable=False),
+            pa.field("engine_version", pa.int64(), nullable=False),
+            pa.field("pipeline_name", pa.string(), nullable=False),
+            pa.field("state", pa.string(), nullable=False),
+            pa.field("created_at", pa.timestamp("us", tz="UTC"), nullable=False),
+            pa.field("version_hash", pa.string(), nullable=True),
+            pa.field("_dlt_load_id", pa.string(), nullable=True),
+        ])
+        aware_state_batch = pa.table({
+            "version": [1],
+            "engine_version": [1],
+            "pipeline_name": ["my_pipeline"],
+            "state": ['{"state": true}'],
+            "created_at": [pendulum.datetime(2024, 1, 1, 12, 0, 0, tz="UTC")],
+            "version_hash": ["hash1"],
+            "_dlt_load_id": ["load1"],
+        }, schema=aware_arrow_schema)
+        state_table_schema = {
+            "name": "_dlt_pipeline_state",
+            "write_disposition": "append",
+            "columns": {
+                "version": {"data_type": "bigint", "nullable": False},
+                "engine_version": {"data_type": "bigint", "nullable": False},
+                "pipeline_name": {"data_type": "text", "nullable": False},
+                "state": {"data_type": "text", "nullable": False},
+                "created_at": {"data_type": "timestamp", "nullable": False},
+                "version_hash": {"data_type": "text", "nullable": True},
+                "_dlt_load_id": {"data_type": "text", "nullable": True},
+            },
+        }
+
+        client._commit_table_files(
+            catalog=catalog,
+            identifier="test._dlt_pipeline_state_tz",
+            table_name="_dlt_pipeline_state",
+            file_data=[(state_table_schema, "state.parquet", aware_state_batch)],
+        )
+
+        state_table = catalog.load_table("test._dlt_pipeline_state_tz")
+        created_at_field = state_table.schema().find_field("created_at")
+        assert isinstance(created_at_field.field_type, TimestamptzType)
+
+        stored_rows = state_table.scan().to_arrow()
+        assert stored_rows.column("created_at").type == pa.timestamp("us", tz="UTC")
+        assert len(stored_rows) == 1
 
     def test_derive_schema_from_iceberg_tables(self, catalog_setup, client):
         """Test that schema can be derived from existing Iceberg tables."""


### PR DESCRIPTION
## Summary
- Normalize dlt internal metadata timestamp columns before Iceberg schema inference/evolution.
- Keep `_dlt_pipeline_state.created_at` as Iceberg `timestamp` when incoming Arrow batches are `timestamp[us, tz=UTC]`.
- Align `_dlt_loads.inserted_at` with the existing naive UTC `TimestampType` convention used by `_dlt_version`.

Addresses #9.

## Tests
- `uv run pytest tests/test_with_state_sync.py::TestWithStateSyncMethods::test_state_table_created_at_timestamptz_batch_matches_existing_timestamp_schema -q`
- `uv run pytest tests/test_with_state_sync.py tests/test_load_metadata_resilience.py tests/test_schema_evolution.py -q`
- `uv run pytest tests/test_class_based_atomic.py tests/test_e2e_sqlite_catalog.py tests/test_destination_e2e.py -q`
- `uv run pytest tests/test_schema_converter.py tests/test_schema_casting.py tests/test_state_sync_e2e.py -q`
- `uv run pytest -q -m "not integration"` (`148 passed, 15 deselected`)
