### PR TITLE
Improve merge primary key filter construction

### DIFF
--- a/src/dlt_iceberg/destination.py
+++ b/src/dlt_iceberg/destination.py
@@ -32,6 +32,7 @@ from .error_handling import (
     log_error_with_context,
     get_user_friendly_error_message,
 )
+from .merge_utils import build_primary_key_delete_filter
 from pyiceberg.io.pyarrow import schema_to_pyarrow
 
 logger = logging.getLogger(__name__)
@@ -71,39 +72,10 @@ def _execute_delete_insert(iceberg_table, arrow_table, primary_keys: list, ident
     Returns:
         Tuple of (rows_deleted_estimate, rows_inserted)
     """
-    from pyiceberg.expressions import In, And, EqualTo, Or
-
     # Build delete filter from primary key values in incoming data
-    if len(primary_keys) == 1:
-        pk_col = primary_keys[0]
-        pk_values = arrow_table.column(pk_col).to_pylist()
-        unique_pk_values = list(set(pk_values))
-        delete_filter = In(pk_col, unique_pk_values)
-        deleted_estimate = len(unique_pk_values)
-    else:
-        # Composite primary key - build OR of AND conditions
-        pk_tuples = set()
-        for i in range(len(arrow_table)):
-            pk_tuple = tuple(
-                arrow_table.column(pk).to_pylist()[i] for pk in primary_keys
-            )
-            pk_tuples.add(pk_tuple)
-
-        conditions = []
-        for pk_tuple in pk_tuples:
-            and_conditions = [
-                EqualTo(pk, val) for pk, val in zip(primary_keys, pk_tuple)
-            ]
-            if len(and_conditions) == 1:
-                conditions.append(and_conditions[0])
-            else:
-                conditions.append(And(*and_conditions))
-
-        if len(conditions) == 1:
-            delete_filter = conditions[0]
-        else:
-            delete_filter = Or(*conditions)
-        deleted_estimate = len(pk_tuples)
+    delete_filter, deleted_estimate = build_primary_key_delete_filter(
+        arrow_table, primary_keys
+    )
 
     logger.info(
         f"Delete-insert for {identifier}: deleting up to {deleted_estimate} "

--- a/src/dlt_iceberg/destination_client.py
+++ b/src/dlt_iceberg/destination_client.py
@@ -52,6 +52,7 @@ from .error_handling import (
     log_error_with_context,
     get_user_friendly_error_message,
 )
+from .merge_utils import build_primary_key_delete_filter
 from pyiceberg.io.pyarrow import schema_to_pyarrow
 
 logger = logging.getLogger(__name__)
@@ -1106,40 +1107,10 @@ class IcebergRestClient(JobClientBase, WithSqlClient, SupportsOpenTables, WithSt
         Returns:
             Tuple of (rows_deleted_estimate, rows_inserted, hard_deleted)
         """
-        from pyiceberg.expressions import In, And, EqualTo, Or
-
         # Build delete filter from primary key values in incoming data
-        if len(primary_keys) == 1:
-            pk_col = primary_keys[0]
-            pk_values = combined_table.column(pk_col).to_pylist()
-            # Deduplicate values
-            unique_pk_values = list(set(pk_values))
-            delete_filter = In(pk_col, unique_pk_values)
-            deleted_estimate = len(unique_pk_values)
-        else:
-            # Composite primary key - build OR of AND conditions
-            pk_tuples = set()
-            for i in range(len(combined_table)):
-                pk_tuple = tuple(
-                    combined_table.column(pk).to_pylist()[i] for pk in primary_keys
-                )
-                pk_tuples.add(pk_tuple)
-
-            conditions = []
-            for pk_tuple in pk_tuples:
-                and_conditions = [
-                    EqualTo(pk, val) for pk, val in zip(primary_keys, pk_tuple)
-                ]
-                if len(and_conditions) == 1:
-                    conditions.append(and_conditions[0])
-                else:
-                    conditions.append(And(*and_conditions))
-
-            if len(conditions) == 1:
-                delete_filter = conditions[0]
-            else:
-                delete_filter = Or(*conditions)
-            deleted_estimate = len(pk_tuples)
+        delete_filter, deleted_estimate = build_primary_key_delete_filter(
+            combined_table, primary_keys
+        )
 
         logger.info(
             f"Delete-insert for {identifier}: deleting up to {deleted_estimate} "
@@ -1181,7 +1152,6 @@ class IcebergRestClient(JobClientBase, WithSqlClient, SupportsOpenTables, WithSt
         if not hard_delete_col or hard_delete_col not in combined_table.column_names:
             return combined_table, None, 0
 
-        from pyiceberg.expressions import In, And, EqualTo, Or
         import pyarrow.compute as pc
 
         # Get the delete marker column
@@ -1196,34 +1166,7 @@ class IcebergRestClient(JobClientBase, WithSqlClient, SupportsOpenTables, WithSt
             return rows_to_keep, None, 0
 
         # Build delete filter from primary keys of rows to delete
-        if len(primary_keys) == 1:
-            pk_col = primary_keys[0]
-            pk_values = rows_to_delete.column(pk_col).to_pylist()
-            unique_pk_values = list(set(pk_values))
-            delete_filter = In(pk_col, unique_pk_values)
-        else:
-            # Composite primary key
-            pk_tuples = set()
-            for i in range(len(rows_to_delete)):
-                pk_tuple = tuple(
-                    rows_to_delete.column(pk).to_pylist()[i] for pk in primary_keys
-                )
-                pk_tuples.add(pk_tuple)
-
-            conditions = []
-            for pk_tuple in pk_tuples:
-                and_conditions = [
-                    EqualTo(pk, val) for pk, val in zip(primary_keys, pk_tuple)
-                ]
-                if len(and_conditions) == 1:
-                    conditions.append(and_conditions[0])
-                else:
-                    conditions.append(And(*and_conditions))
-
-            if len(conditions) == 1:
-                delete_filter = conditions[0]
-            else:
-                delete_filter = Or(*conditions)
+        delete_filter, _ = build_primary_key_delete_filter(rows_to_delete, primary_keys)
 
         return rows_to_keep, delete_filter, len(rows_to_delete)
 

--- a/src/dlt_iceberg/merge_utils.py
+++ b/src/dlt_iceberg/merge_utils.py
@@ -1,0 +1,42 @@
+"""Utilities shared by merge strategies."""
+
+from typing import Any, List, Tuple
+
+import pyarrow as pa
+
+
+def unique_primary_key_values(table: pa.Table, primary_keys: List[str]) -> set:
+    """Return unique primary-key values without repeatedly materializing Arrow columns."""
+    if len(primary_keys) == 1:
+        return set(table.column(primary_keys[0]).to_pylist())
+
+    key_columns = [table.column(pk).to_pylist() for pk in primary_keys]
+    return set(zip(*key_columns))
+
+
+def build_primary_key_delete_filter(table: pa.Table, primary_keys: List[str]) -> Tuple[Any, int]:
+    """Build a PyIceberg delete expression for the unique primary keys in table."""
+    from pyiceberg.expressions import AlwaysFalse, And, EqualTo, In, Or
+
+    unique_key_values = unique_primary_key_values(table, primary_keys)
+
+    if len(primary_keys) == 1:
+        return In(primary_keys[0], list(unique_key_values)), len(unique_key_values)
+
+    conditions = []
+    for pk_tuple in unique_key_values:
+        and_conditions = [
+            EqualTo(pk, val) for pk, val in zip(primary_keys, pk_tuple)
+        ]
+        if len(and_conditions) == 1:
+            conditions.append(and_conditions[0])
+        else:
+            conditions.append(And(*and_conditions))
+
+    if len(conditions) == 0:
+        return AlwaysFalse(), 0
+
+    if len(conditions) == 1:
+        return conditions[0], len(unique_key_values)
+
+    return Or(*conditions), len(unique_key_values)

--- a/tests/test_merge_utils.py
+++ b/tests/test_merge_utils.py
@@ -1,0 +1,45 @@
+from dlt_iceberg.merge_utils import build_primary_key_delete_filter
+
+
+class CountingColumn:
+    def __init__(self, values):
+        self.values = values
+        self.to_pylist_calls = 0
+
+    def to_pylist(self):
+        self.to_pylist_calls += 1
+        return self.values
+
+
+class CountingTable:
+    def __init__(self, columns):
+        self.columns = {
+            name: CountingColumn(values)
+            for name, values in columns.items()
+        }
+
+    def column(self, name):
+        return self.columns[name]
+
+
+def test_composite_primary_key_filter_materializes_each_column_once():
+    table = CountingTable(
+        {
+            "user_id": [1, 1, 2, 2, 2],
+            "event_date": [
+                "2024-01-01",
+                "2024-01-01",
+                "2024-01-01",
+                "2024-01-02",
+                "2024-01-02",
+            ],
+        }
+    )
+
+    _, unique_count = build_primary_key_delete_filter(
+        table, ["user_id", "event_date"]
+    )
+
+    assert unique_count == 3
+    assert table.columns["user_id"].to_pylist_calls == 1
+    assert table.columns["event_date"].to_pylist_calls == 1


### PR DESCRIPTION
## Summary
- add a shared merge utility for primary-key delete filter construction
- avoid repeatedly materializing Arrow columns while building composite-key delete filters
- reuse the helper in class-based, hard-delete, and legacy function-based delete-insert paths
- add a regression test that composite key columns are materialized once per key column

## Benchmark notes
Related to #7. Ran scoped probes on `nicbook-atm` over SSH. Composite-key filter construction improved from 0.262s to 0.003s at 1k rows and from 6.554s to 0.018s at 5k rows. Fixed-path-only probes: 10k rows 0.038s, 25k rows 0.095s, 50k rows 0.222s.

SQLite `pipeline.run` probes also passed for delete-insert and upsert at modest sizes; I did not reproduce exit 138 in those scoped local/remote probes.

## Tests
- `uv run pytest tests/test_merge_utils.py tests/test_delete_insert_merge.py tests/test_merge_disposition.py -q`
